### PR TITLE
don't flag that a model has changes unless values are different

### DIFF
--- a/pydantic_changedetect/changedetect.py
+++ b/pydantic_changedetect/changedetect.py
@@ -221,7 +221,8 @@ class ChangeDetectionMixin(pydantic.BaseModel):
         if name in self_compat.model_fields and name not in self.model_original:
             self.model_original[name] = self.__dict__[name]
         super().__setattr__(name, value)
-        self.model_self_changed_fields.add(name)
+        if self.model_original[name] != value:
+            self.model_self_changed_fields.add(name)
 
     def __getstate__(self) -> Dict[str, Any]:
         state = super().__getstate__()

--- a/tests/test_changedetect.py
+++ b/tests/test_changedetect.py
@@ -70,6 +70,14 @@ def test_set_changed_state():
     assert obj.model_changed_fields == {"id"}
 
 
+def test_values_did_not_change():
+    obj = Something(id=1)
+    assert not obj.model_has_changed
+    obj.id = 1
+    assert not obj.model_has_changed
+    assert obj.model_changed_fields == set()
+
+
 def test_set_changed_state_with_fixed_original():
     obj = Something(id=1)
 


### PR DESCRIPTION
Fixes #17.

Turns out this was a straight forward change. LMK if you have any questions. Works flawlessly on my code base (with 