### PR TITLE
Solve #17: Check value equality for scalar field values

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,14 @@ something.model_has_changed  # = True
 something.model_changed_fields  # = {"name"}
 ```
 
-### Restrictions
+### When will a change be detected
+
+`pydantic-changedetect` will see changes when an attribute value is changes using an
+attribute assignment like `something.name = "something else"` in the example above. Such
+an assignment will be seen as a change unless the new value is the same and the type of
+the value is `None` or of type `str`, `int`, `float`, `bool` or `decimal.Decimal`.
+
+#### Restrictions
 
 `ChangeDetectionMixin` currently cannot detect changes inside lists, dicts and
 other structured objects. In those cases you are required to set the changed
@@ -62,6 +69,23 @@ state yourself using `model_set_changed()`. It is recommended to pass the origin
 value to `model_set_changed()` when you want to also keep track of the actual changes
 compared to the original value. Be advised to `.copy()` the original value
 as lists/dicts will always be changed in place.
+
+Example:
+```python
+import pydantic
+from pydantic_changedetect import ChangeDetectionMixin
+
+class TodoList(ChangeDetectionMixin, pydantic.BaseModel):
+    items: list[str]
+
+
+todos = TodoList(items=["release new version"])
+original_items = todos.items.copy()
+todos.items.append("create better docs")  # This change will NOT be seen yet
+todos.model_has_changed  # = False
+todos.model_set_changed("items", original=original_items)  # Mark field as changed
+todos.model_has_changed  # = False
+```
 
 # Contributing
 

--- a/pydantic_changedetect/changedetect.py
+++ b/pydantic_changedetect/changedetect.py
@@ -206,7 +206,7 @@ class ChangeDetectionMixin(pydantic.BaseModel):
                 self.model_original[name] = original
             self.model_self_changed_fields.add(name)
 
-    def _model_is_change_comparable_type(self, value: Any) -> bool:
+    def _model_value_is_comparable_type(self, value: Any) -> bool:
         return (
             value is None
             or isinstance(value, (str, int, float, bool, decimal.Decimal))
@@ -241,8 +241,8 @@ class ChangeDetectionMixin(pydantic.BaseModel):
             # (when validate_assignment == True)
             current_value = self.__dict__[name]
             if (
-                self._model_is_change_comparable_type(original_value)
-                and self._model_is_change_comparable_type(current_value)
+                self._model_value_is_comparable_type(original_value)
+                and self._model_value_is_comparable_type(current_value)
                 and original_value == current_value
             ):
                 has_changed = False


### PR DESCRIPTION
Check scalar values for equality for scalar field values. Only mark fields as changed if new value is different.

Also fixes issue that original value was stored even when validation errors occurred. Now the original value is only stored when everything went through.