### PR TITLE
feat(model_construct): handle partially hydrated models

### DIFF
--- a/pydantic_changedetect/changedetect.py
+++ b/pydantic_changedetect/changedetect.py
@@ -99,6 +99,10 @@ class ChangeDetectionMixin(pydantic.BaseModel):
 
         changed_fields = self.model_self_changed_fields.copy()
         for field_name, model_field in self_compat.model_fields.items():
+            # Support for instances created through model_construct, when not all fields have been defined
+            if field_name not in self.__dict__:
+                continue
+
             field_value = self.__dict__[field_name]
 
             # Value is a ChangeDetectionMixin instance itself

--- a/tests/test_changedetect.py
+++ b/tests/test_changedetect.py
@@ -14,6 +14,11 @@ class Something(ChangeDetectionMixin, pydantic.BaseModel):
     id: int
 
 
+class SomethingMultipleFields(ChangeDetectionMixin, pydantic.BaseModel):
+    id: int
+    foo: str
+
+
 class Unsupported(pydantic.BaseModel):
     id: int
 
@@ -477,6 +482,17 @@ def test_model_construct_works():
     something.id = 2
 
     assert something.model_has_changed is True
+
+
+@pytest.mark.skipif(PYDANTIC_V1, reason="pydantic v1 does not support model_construct()")
+def test_model_construct_works_for_models_loaded_with_few_fields():
+    something_multiple_fields = SomethingMultipleFields.model_construct(id=1)
+
+    assert something_multiple_fields.model_has_changed is False
+
+    something_multiple_fields.id = 2
+
+    assert something_multiple_fields.model_has_changed is True
 
 
 @pytest.mark.skipif(PYDANTIC_V1, reason="pydantic v1 does not trigger warnings")


### PR DESCRIPTION
When working with an instance of a model implementing `ChangeDetectionMixin` that have been instanciated through `model_construct` and with not all fields being set, it does raise a `KeyError`.

This PR highlights the use-case in a test and fixes it in `model_changed_fields` method of `ChangeDetectionMixin`.

It seems to be aligned with the idea behind the tool, to still be able to detect fields being changed within a partially hydrated instance.

Let me know if you're ok with the ide, and if you want it to be extended / done differently.

Thanks !
